### PR TITLE
Add testing support

### DIFF
--- a/squery_lite/__init__.py
+++ b/squery_lite/__init__.py
@@ -1,1 +1,1 @@
-__version__ = '1.0'
+__version__ = '1.1.dev1'

--- a/squery_lite/pytest_fixtures.py
+++ b/squery_lite/pytest_fixtures.py
@@ -1,0 +1,38 @@
+"""
+This module contains fixtures for use with py.test test runner.
+"""
+
+import pytest
+
+from .testing import TestContainer
+
+
+@pytest.fixture(scope='session')
+def database_container(request, database_config):
+    """
+    A test database container with automatic tear-down. This fixture requires
+    you to define a ``database_config`` session-scoped fixture that returns a
+    dict containing keyword arguments for the :py:class:`TestContainer` class.
+
+    To speed the tests up, no set-up is done.
+
+    This is a session-scoped fixture and tear-down is performed after all tests
+    are done.
+    """
+    container = TestContainer(**database_config)
+
+    def teardown():
+        container.teardownall()
+    request.addfinalizer(teardown)
+    return container
+
+
+@pytest.fixture
+def databases(database_container):
+    """
+    Database container with setup performed for all databases. You should
+    create your own fixtures that depend on the :py:func:`database_container`
+    fixture if you wish to avoid running the setup on all tables.
+    """
+    database_container.setupall()
+    return database_container

--- a/squery_lite/squery.py
+++ b/squery_lite/squery.py
@@ -10,6 +10,7 @@ file that comes with the source code, or http://www.gnu.org/licenses/gpl.txt.
 
 from __future__ import print_function
 
+import os
 import calendar
 import contextlib
 import datetime
@@ -219,6 +220,14 @@ class Database(object):
     @classmethod
     def connect(cls, database, **kwargs):
         return Connection(database)
+
+    def recreate(self, path):
+        self.drop(path)
+        self.connect(path)
+
+    @classmethod
+    def drop(cls, path):
+        os.remove(path)
 
     def __repr__(self):
         return "<Database connection='%s'>" % self.conn.path

--- a/squery_lite/testing.py
+++ b/squery_lite/testing.py
@@ -1,0 +1,111 @@
+"""
+This module contains classes and functions useful when testing an application
+using squery-pg.
+"""
+
+import os
+import hashlib
+
+from .squery import Database
+
+
+def random_name(prefix='test'):
+    """
+    Return random name that can be used to create the test database.
+    """
+    rndbytes = os.urandom(8)
+    md5 = hashlib.md5()
+    md5.update(rndbytes)
+    return '{}_{}'.format(prefix, md5.hexdigest()[:7])
+
+
+class TestContainer(object):
+    """
+    Return an instance of a database container that adds features relevant to
+    testing. The container supports mutliple databases.
+
+    The ``databases`` argument should be an iterable containing database
+    information. Each member should be a dict that has 'name' and 'migrations'
+    keys. The 'name' key maps to the database name, while the 'migration' key
+    should be a string representing the name of the Python package that
+    contains migrations for the database. Migrations are optional.
+
+    .. note::
+        The actual name of the database will be the database name with a
+        '_test_<random_string>' suffix, while we still refer to it using the
+        name specified in the ``databases`` argument.
+
+    ``conf`` argument is a dictionary of application options that are passed to
+    the migrations.
+
+    The test runner / test code should invoke the
+    :py:meth:`~TestContainer.setup` method to create an migrate the database,
+    and :py:meth:`~TestContainer.teardown` method to tear it down and
+    disconnect. Note that it is not necessary to tear down before set-up as the
+    set-up code will recreate all tables. Full tear-down is only necessary
+    after all test code that requires the database has finished using it.
+
+    The location for the databases is specified using the ``path`` argument.
+    The default value is ``'/tmp'``
+    """
+
+    def __init__(self, databases, path='/tmp', conf={}):
+        self.conf = conf
+        self.databases = {}
+        self.add_databases(databases)
+
+    def add_databases(self, databases):
+        for database in databases:
+            self.add_database(database)
+
+    def add_database(self, database):
+        name = database['name']
+        migrations = database.get('migrations')
+        real_dbname = os.path.join(random_name('test_{}'.format(name)))
+        conn = Database.connect(database=real_dbname)
+        self.databases[name] = {
+            'name': real_dbname,
+            'db': Database(conn),
+            'migrations': migrations,
+        }
+
+    def load_fixtures(self, dbname, table, data):
+        """
+        Load fixtures from ``data`` iterable into specified table. The data is
+        epxeced to be an iterable of dicts.
+        """
+        db = self.databases[dbname]['db']
+        db.execute('BEGIN')
+        for row in data:
+            columns = row.keys()
+            q = db.Insert(table, cols=columns)
+            db.execute(q, row)
+        db.execute('COMMIT')
+
+    def setupall(self):
+        for dbname in self.databases:
+            self.setup(dbname)
+
+    def setup(self, dbname):
+        db = self.databases[dbname]['db']
+        path = self.databases[dbname]['name']
+        migrations = self.databases[dbname]['migrations']
+        db.recreate(path)
+        if migrations:
+            Database.migrate(db, migrations, self.conf)
+
+    def teardownall(self):
+        for dbname in self.databases:
+            self.teardown(dbname)
+
+    def teardown(self, dbname):
+        name = self.databases[dbname]['name']
+        db = self.databases[dbname]['db']
+        db.close()
+        Database.drop(name)
+
+    def __getattr__(self, name):
+        try:
+            return self.databases[name]['db']
+        except KeyError:
+            return object.__getattr__(self, name)


### PR DESCRIPTION
This patch adds a TestContainer container class that allows managing test
databases and two py.test fixtures.

Resolves #1 
